### PR TITLE
Implement workaround for issue #14

### DIFF
--- a/app/src/main/java/ch/tiim/markdown_widget/MarkdownFileWidgetConfigureActivity.kt
+++ b/app/src/main/java/ch/tiim/markdown_widget/MarkdownFileWidgetConfigureActivity.kt
@@ -10,6 +10,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import android.webkit.MimeTypeMap
 import android.widget.EditText
 import android.widget.RadioGroup
 import android.widget.RemoteViews
@@ -34,10 +35,18 @@ class MarkdownFileWidgetConfigureActivity : Activity() {
     private lateinit var inputFilePath: EditText
     private lateinit var radioGroup: RadioGroup
     private val onBrowse = View.OnClickListener {
+        // Workaround for https://github.com/Tiim/Android-Markdown-Widget/issues/14:
+        // Check if MIME-Type "text/markdown" is known. Otherwise fall back to
+        // generic type to still allow file selection.
+        val mimetype = if (MimeTypeMap.getSingleton().hasMimeType("text/markdown")) {
+            "text/markdown"
+        } else {
+            "*/*"
+        }
         // https://developer.android.com/reference/android/content/Intent#ACTION_OPEN_DOCUMENT
         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
             addCategory(Intent.CATEGORY_OPENABLE)
-            type = "text/markdown"
+            type = mimetype
             flags = Intent.FLAG_GRANT_READ_URI_PERMISSION.or( Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
         }
         startActivityForResult(Intent.createChooser(intent, "Select a markdown file"), ACTIVITY_RESULT_BROWSE)


### PR DESCRIPTION
Fixes #14.

Older Android SDKs don't implement MIME type "text/markdown". This leads to markdown files not being available for selection.

This workaround checks if "text/markdown" is a known MIME type. Otherwise it will fall back to the broader "\*/\*".
This way, functionality for already working versions is not altered.

Possible issue with this workaround: Instead of not being able to select files, it is now possible to select any file regardless of file type. This only affects devices, where "text/markdown" is not known.

I tested it successfully on Android 8 ("text/markdown" not known) and Android 12 ("text/markdown" known).