### PR TITLE
Widget background color picker, Custom CSS injection

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+Markdown-Widget

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,13 +7,13 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.6.21" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -14,7 +14,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,7 @@ android {
     packagingOptions {
         resources.excludes.add("META-INF/*")
     }
+    namespace 'ch.tiim.markdown_widget'
 }
 
 android.applicationVariants.all { variant ->

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
     implementation 'com.vladsch.flexmark:flexmark-all:0.64.0'
+    implementation 'com.github.Dhaval2404:ColorPicker:2.3'
 
 
     testImplementation 'junit:junit:4.13.2'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="ch.tiim.markdown_widget">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/ch/tiim/markdown_widget/MainActivity.kt
+++ b/app/src/main/java/ch/tiim/markdown_widget/MainActivity.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
-import android.widget.ImageView
 import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
 

--- a/app/src/main/java/ch/tiim/markdown_widget/MarkdownFileWidget.kt
+++ b/app/src/main/java/ch/tiim/markdown_widget/MarkdownFileWidget.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import android.content.res.Resources
 import android.database.Cursor
+import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
@@ -85,6 +86,8 @@ class MarkdownFileWidget : AppWidgetProvider() {
 
         val tapBehavior = loadPref(context, appWidgetId, PREF_BEHAVIOUR, TAP_BEHAVIOUR_DEFAULT_APP)
         val fileUri = Uri.parse(loadPref(context, appWidgetId, PREF_FILE, ""))
+        var bgColor = loadPref(context, appWidgetId, PREF_BGCOLOR, Color.WHITE.toString()).toInt()
+        var customCSS = loadPref(context, appWidgetId, PREF_CSS, "")
 
         val s = loadMarkdown(context, fileUri)
 
@@ -94,7 +97,7 @@ class MarkdownFileWidget : AppWidgetProvider() {
                 s
             )
         ) {
-            cachedMarkdown.put(appWidgetId, MarkdownRenderer(context, width, height, s))
+            cachedMarkdown.put(appWidgetId, MarkdownRenderer(context, width, height, s, bgColor, customCSS))
         }
         val md = cachedMarkdown[appWidgetId]
 

--- a/app/src/main/java/ch/tiim/markdown_widget/MarkdownParser.kt
+++ b/app/src/main/java/ch/tiim/markdown_widget/MarkdownParser.kt
@@ -49,12 +49,12 @@ class MarkdownParser(private val theme:String) {
             <!DOCTYPE html>
             <html>
                 <head>
-                    <styles>
-                        ${theme}
-                    </styles>
+                    <style>
+                        $theme
+                    </style>
                 </head>
                 <body>
-                    ${html}
+                    $html
                 </body>
             </html>"""
     }

--- a/app/src/main/java/ch/tiim/markdown_widget/MarkdownRenderer.kt
+++ b/app/src/main/java/ch/tiim/markdown_widget/MarkdownRenderer.kt
@@ -15,9 +15,9 @@ import kotlin.math.max
 
 
 private const val TAG = "MarkdownRenderer"
-class MarkdownRenderer(private val context: Context, private val width: Int, private val height: Int, private val data: String, private val onReady: ((Bitmap) -> Unit) = {}) {
+class MarkdownRenderer(private val context: Context, private val width: Int, private val height: Int, private val data: String, private val bgColor: Int = Color.WHITE, private val customCSS: String = "", private val onReady: ((Bitmap) -> Unit) = {}) {
 
-    private val mdParser = MarkdownParser("")
+    private val mdParser = MarkdownParser(customCSS)
     val webView = WebView(context);
     private val bitmap = Bitmap.createBitmap(max(width, 100), max(height, 100), Bitmap.Config.ARGB_8888)
     private val canvas = Canvas(bitmap)
@@ -25,11 +25,12 @@ class MarkdownRenderer(private val context: Context, private val width: Int, pri
 
     init {
         val html = getHtml(data);
-        prepareWebView(html)
+        prepareWebView(html, bgColor)
     }
 
     private fun prepareWebView(
-        html: String
+        html: String,
+        bgColor: Int = Color.WHITE
     ) {
         webView.webViewClient = object: WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
@@ -47,12 +48,13 @@ class MarkdownRenderer(private val context: Context, private val width: Int, pri
             }
         }
         webView.layout(0, 0, width, height)
-        webView.setBackgroundColor(Color.WHITE)
+
+        webView.setBackgroundColor(bgColor)
         //webView.setBackgroundColor(Color.MAGENTA)
         val encodedHtml = Base64.encodeToString(html.toByteArray(), Base64.DEFAULT)
         webView.loadData(encodedHtml, "text/html", "base64")
-        webView.isDrawingCacheEnabled = true
-        webView.buildDrawingCache()
+        // webView.isDrawingCacheEnabled = true
+        // webView.buildDrawingCache()
     }
 
     fun isReady():Boolean {

--- a/app/src/main/res/drawable/textborder.xml
+++ b/app/src/main/res/drawable/textborder.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
+    <stroke android:width="1dip" android:color="@color/colorAccent"/>
+</shape>

--- a/app/src/main/res/layout/markdown_file_widget_configure.xml
+++ b/app/src/main/res/layout/markdown_file_widget_configure.xml
@@ -47,6 +47,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <RadioGroup
@@ -79,6 +80,52 @@
             android:layout_height="wrap_content"
             android:text="Do not open" />
     </RadioGroup>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/colorselect"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <Button
+            android:id="@+id/bgcolor_button"
+            android:layout_width="203dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="20dp"
+            android:text="Background Color"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/selectedColor"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/selectedColor"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:layout_marginStart="20dp"
+            android:background="@drawable/textborder"
+            android:outlineProvider="paddedBounds"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/bgcolor_button"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <TextView
+        android:id="@+id/customCSSLabel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:labelFor="@id/customCSS"
+        android:text="Custom CSS:" />
+
+    <EditText
+        android:id="@+id/customCSS"
+        android:layout_width="match_parent"
+        android:layout_height="153dp"
+        android:ems="10"
+        android:gravity="start|top"
+        android:hint="/** e.g. body { color: #fff; } **/"
+        android:inputType="textMultiLine" />
 
     <Button
         android:id="@+id/add_button"

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.1.2' apply false
-    id 'com.android.library' version '7.1.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.5.30' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Mar 26 21:28:57 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,7 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 dependencyResolutionManagement {
@@ -10,7 +11,7 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         google()
-        //maven { url "https://jitpack.io" }
+        maven { url "https://jitpack.io" }
     }
 }
 rootProject.name = "Markdown-Widget"


### PR DESCRIPTION
This adds the ability to select a color for the widget background as well as adding custom CSS into the rendered widget.


![Screenshot_20231227-132019](https://github.com/Tiim/Android-Markdown-Widget/assets/75656/7f9564ad-cf0a-4e6e-9b5f-1040f3c4604d)
![Screenshot_20231227-131835](https://github.com/Tiim/Android-Markdown-Widget/assets/75656/518c8efe-363d-42a9-853b-2ac6b6ae6c1c)
![Screenshot_20231227-131933](https://github.com/Tiim/Android-Markdown-Widget/assets/75656/686eb5b7-86f5-4d14-8cce-2b95e659dc88)
![Screenshot_20231227-132011](https://github.com/Tiim/Android-Markdown-Widget/assets/75656/857fc613-9419-4863-b954-5b4126b1a764)
